### PR TITLE
Fix for issue #7 (Display "4:00" instead of "04:00")

### DIFF
--- a/app/src/main/java/com/emmaguy/cleanstatusbar/prefs/TimePreference.java
+++ b/app/src/main/java/com/emmaguy/cleanstatusbar/prefs/TimePreference.java
@@ -57,7 +57,7 @@ public class TimePreference extends DialogPreference {
 
     private String toTimeDigits(int i) {
         String digit = String.valueOf(i);
-        if(i < 9) {
+        if (i < 10) {
             digit = "0" + digit;
         }
         return digit;


### PR DESCRIPTION
- Display hour digit in status bar without appending '0'
- Append '0' to minute for all numbers below 10 (including 9)
